### PR TITLE
fix: ensure TUIC outbounds always include tls

### DIFF
--- a/internal/builder/singbox.go
+++ b/internal/builder/singbox.go
@@ -574,7 +574,32 @@ func (b *ConfigBuilder) nodeToOutbound(node storage.Node) Outbound {
 		outbound[k] = v
 	}
 
+	if node.Type == "tuic" {
+		b.ensureTUICOutboundTLS(outbound)
+	}
+
 	return outbound
+}
+
+func (b *ConfigBuilder) ensureTUICOutboundTLS(outbound Outbound) {
+	tlsValue, exists := outbound["tls"]
+	if !exists || tlsValue == nil {
+		outbound["tls"] = map[string]interface{}{
+			"enabled": true,
+		}
+		return
+	}
+
+	switch tls := tlsValue.(type) {
+	case map[string]interface{}:
+		tls["enabled"] = true
+	case Outbound:
+		tls["enabled"] = true
+	default:
+		outbound["tls"] = map[string]interface{}{
+			"enabled": true,
+		}
+	}
 }
 
 // matchFilter 检查节点是否匹配过滤器

--- a/internal/builder/singbox_test.go
+++ b/internal/builder/singbox_test.go
@@ -1,0 +1,30 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/xiaobei/singbox-manager/internal/storage"
+)
+
+func TestConfigBuilder_NodeToOutbound_TUICEnsuresTLS(t *testing.T) {
+	b := NewConfigBuilder(storage.DefaultSettings(), nil, nil, nil, nil)
+
+	outbound := b.nodeToOutbound(storage.Node{
+		Tag:        "tuic-node",
+		Type:       "tuic",
+		Server:     "example.com",
+		ServerPort: 443,
+		Extra: map[string]interface{}{
+			"uuid":     "11111111-1111-1111-1111-111111111111",
+			"password": "secret",
+		},
+	})
+
+	tls, ok := outbound["tls"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("outbound[\"tls\"] type = %T, want map[string]interface{}", outbound["tls"])
+	}
+	if enabled, ok := tls["enabled"].(bool); !ok || !enabled {
+		t.Fatalf("tls.enabled = %#v, want true", tls["enabled"])
+	}
+}

--- a/internal/parser/clash_yaml.go
+++ b/internal/parser/clash_yaml.go
@@ -198,6 +198,21 @@ func convertClashProxy(proxy ClashProxy) (*storage.Node, error) {
 		if proxy.ReduceRTT {
 			extra["zero_rtt_handshake"] = true
 		}
+		tls := map[string]interface{}{
+			"enabled": true,
+		}
+		if proxy.SNI != "" {
+			tls["server_name"] = proxy.SNI
+		} else if proxy.Servername != "" {
+			tls["server_name"] = proxy.Servername
+		}
+		if proxy.SkipCertVerify {
+			tls["insecure"] = true
+		}
+		if len(proxy.ALPN) > 0 {
+			tls["alpn"] = proxy.ALPN
+		}
+		extra["tls"] = tls
 
 	case "socks", "socks5":
 		nodeType = "socks"

--- a/internal/parser/clash_yaml_test.go
+++ b/internal/parser/clash_yaml_test.go
@@ -1,0 +1,56 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseClashYAML_TUICIncludesTLS(t *testing.T) {
+	content := `
+proxies:
+  - name: "TUIC Test"
+    type: tuic
+    server: example.com
+    port: 443
+    uuid: 11111111-1111-1111-1111-111111111111
+    password: secret
+    sni: edge.example.com
+    skip-cert-verify: true
+    alpn:
+      - h3
+    congestion-controller: bbr
+    udp-relay-mode: native
+    reduce-rtt: true
+`
+
+	nodes, err := ParseClashYAML(content)
+	if err != nil {
+		t.Fatalf("ParseClashYAML() error = %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("ParseClashYAML() node count = %d, want 1", len(nodes))
+	}
+
+	node := nodes[0]
+	if node.Type != "tuic" {
+		t.Fatalf("node.Type = %q, want %q", node.Type, "tuic")
+	}
+
+	tls, ok := node.Extra["tls"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("node.Extra[\"tls\"] type = %T, want map[string]interface{}", node.Extra["tls"])
+	}
+	if enabled, ok := tls["enabled"].(bool); !ok || !enabled {
+		t.Fatalf("tls.enabled = %#v, want true", tls["enabled"])
+	}
+	if serverName := tls["server_name"]; serverName != "edge.example.com" {
+		t.Fatalf("tls.server_name = %#v, want %q", serverName, "edge.example.com")
+	}
+	if insecure, ok := tls["insecure"].(bool); !ok || !insecure {
+		t.Fatalf("tls.insecure = %#v, want true", tls["insecure"])
+	}
+
+	alpn, ok := tls["alpn"].([]string)
+	if !ok || len(alpn) != 1 || alpn[0] != "h3" {
+		t.Fatalf("tls.alpn = %#v, want [\"h3\"]", tls["alpn"])
+	}
+}


### PR DESCRIPTION
## Summary
- add missing `tls` config when converting TUIC nodes from Clash YAML
- ensure generated sing-box TUIC outbounds always include `tls.enabled = true` as a compatibility fallback
- add parser and builder tests covering the TUIC TLS requirement

## Validation
- `go test ./internal/parser ./internal/builder`
- test tag `v0.2.14-tuic-tls-test` has been verified successfully by the issue reporter/user

Closes #11